### PR TITLE
Fix warranty field naming

### DIFF
--- a/sistema-chamados/app/Http/Controllers/AssetController.php
+++ b/sistema-chamados/app/Http/Controllers/AssetController.php
@@ -130,7 +130,8 @@ class AssetController extends Controller
             'assigned_to' => 'nullable|exists:users,id',
             'purchase_date' => 'nullable|date',
             'purchase_cost' => 'nullable|numeric|min:0',
-            'warranty_expires' => 'nullable|date',
+            // Nome correto do campo de garantia
+            'warranty_end' => 'nullable|date',
             'notes' => 'nullable|string',
             'custom_fields' => 'nullable|array'
         ]);
@@ -182,7 +183,8 @@ class AssetController extends Controller
             'assigned_to' => 'nullable|exists:users,id',
             'purchase_date' => 'nullable|date',
             'purchase_cost' => 'nullable|numeric|min:0',
-            'warranty_expires' => 'nullable|date',
+            // Nome correto do campo de garantia
+            'warranty_end' => 'nullable|date',
             'notes' => 'nullable|string',
             'custom_fields' => 'nullable|array'
         ]);

--- a/sistema-chamados/app/Http/Controllers/ReportController.php
+++ b/sistema-chamados/app/Http/Controllers/ReportController.php
@@ -185,12 +185,12 @@ class ReportController extends Controller
         }
 
         if ($request->has('under_warranty') && $request->under_warranty === '1') {
-            $query->whereNotNull('warranty_expires')
-                  ->where('warranty_expires', '>=', now());
+            $query->whereNotNull('warranty_end')
+                  ->where('warranty_end', '>=', now());
         } elseif ($request->has('under_warranty') && $request->under_warranty === '0') {
             $query->where(function($q) {
-                $q->whereNull('warranty_expires')
-                  ->orWhere('warranty_expires', '<', now());
+                $q->whereNull('warranty_end')
+                  ->orWhere('warranty_end', '<', now());
             });
         }
 
@@ -227,8 +227,8 @@ class ReportController extends Controller
             
         // Ativos com garantia expirada
         $expiredWarrantyCount = $query->clone()
-            ->whereNotNull('warranty_expires')
-            ->where('warranty_expires', '<', now())
+            ->whereNotNull('warranty_end')
+            ->where('warranty_end', '<', now())
             ->count();
 
         // Resultados paginados para tabela

--- a/sistema-chamados/resources/views/assets/create.blade.php
+++ b/sistema-chamados/resources/views/assets/create.blade.php
@@ -164,10 +164,10 @@
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="warranty_expires">Garantia Expira</label>
-                                    <input type="date" class="form-control @error('warranty_expires') is-invalid @enderror" 
-                                           id="warranty_expires" name="warranty_expires" value="{{ old('warranty_expires', $duplicateAsset->warranty_expires ?? '') }}">
-                                    @error('warranty_expires')
+                                    <label for="warranty_end">Garantia Expira</label>
+                                    <input type="date" class="form-control @error('warranty_end') is-invalid @enderror"
+                                           id="warranty_end" name="warranty_end" value="{{ old('warranty_end', $duplicateAsset->warranty_end ?? '') }}">
+                                    @error('warranty_end')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </div>

--- a/sistema-chamados/resources/views/assets/edit.blade.php
+++ b/sistema-chamados/resources/views/assets/edit.blade.php
@@ -170,10 +170,10 @@
                                 </div>
 
                                 <div class="form-group">
-                                    <label for="warranty_expires">Garantia Expira</label>
-                                    <input type="date" class="form-control @error('warranty_expires') is-invalid @enderror" 
-                                           id="warranty_expires" name="warranty_expires" value="{{ old('warranty_expires', $asset->warranty_expires?->format('Y-m-d')) }}">
-                                    @error('warranty_expires')
+                                    <label for="warranty_end">Garantia Expira</label>
+                                    <input type="date" class="form-control @error('warranty_end') is-invalid @enderror"
+                                           id="warranty_end" name="warranty_end" value="{{ old('warranty_end', $asset->warranty_end?->format('Y-m-d')) }}">
+                                    @error('warranty_end')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </div>

--- a/sistema-chamados/resources/views/assets/show.blade.php
+++ b/sistema-chamados/resources/views/assets/show.blade.php
@@ -120,11 +120,11 @@
                                 <tr>
                                     <td><strong>Garantia Expira:</strong></td>
                                     <td>
-                                        @if($asset->warranty_expires)
-                                            {{ $asset->warranty_expires->format('d/m/Y') }}
-                                            @if($asset->warranty_expires->isPast())
+                                        @if($asset->warranty_end)
+                                            {{ $asset->warranty_end->format('d/m/Y') }}
+                                            @if($asset->warranty_end->isPast())
                                                 <span class="badge badge-danger ml-1">Expirada</span>
-                                            @elseif($asset->warranty_expires->diffInDays() <= 30)
+                                            @elseif($asset->warranty_end->diffInDays() <= 30)
                                                 <span class="badge badge-warning ml-1">Expira em breve</span>
                                             @else
                                                 <span class="badge badge-success ml-1">Válida</span>

--- a/sistema-chamados/resources/views/dashboard.blade.php
+++ b/sistema-chamados/resources/views/dashboard.blade.php
@@ -588,7 +588,7 @@ use Illuminate\Support\Str;
                                         <small class="text-muted">{{ $asset->assetModel->name ?? 'N/A' }}</small>
                                     </div>
                                     <span class="badge badge-warning badge-pill">
-                                        {{ $asset->warranty_expires ? $asset->warranty_expires->diffForHumans() : 'N/A' }}
+                                        {{ $asset->warranty_end ? $asset->warranty_end->diffForHumans() : 'N/A' }}
                                     </span>
                                 </div>
                             </div>

--- a/sistema-chamados/resources/views/dashboard_new.blade.php
+++ b/sistema-chamados/resources/views/dashboard_new.blade.php
@@ -471,7 +471,7 @@ use Illuminate\Support\Str;
                                 <div class="modern-content">
                                     <div class="modern-title">{{ $asset->name }}</div>
                                     <div class="modern-subtitle">
-                                        Garantia: {{ $asset->warranty_expires ? $asset->warranty_expires->diffForHumans() : 'N/A' }}
+                                        Garantia: {{ $asset->warranty_end ? $asset->warranty_end->diffForHumans() : 'N/A' }}
                                     </div>
                                 </div>
                                 <div class="modern-badge badge-new">Atenção</div>

--- a/sistema-chamados/resources/views/reports/assets.blade.php
+++ b/sistema-chamados/resources/views/reports/assets.blade.php
@@ -187,16 +187,16 @@
                                         @endif
                                     </td>
                                     <td>
-                                        @if($asset->warranty_expires)
-                                            @if($asset->warranty_expires->isPast())
+                                        @if($asset->warranty_end)
+                                            @if($asset->warranty_end->isPast())
                                                 <span class="badge badge-danger">Expirada</span>
-                                                <br><small>{{ $asset->warranty_expires->format('d/m/Y') }}</small>
-                                            @elseif($asset->warranty_expires->diffInDays() <= 30)
+                                                <br><small>{{ $asset->warranty_end->format('d/m/Y') }}</small>
+                                            @elseif($asset->warranty_end->diffInDays() <= 30)
                                                 <span class="badge badge-warning">Expira em breve</span>
-                                                <br><small>{{ $asset->warranty_expires->format('d/m/Y') }}</small>
+                                                <br><small>{{ $asset->warranty_end->format('d/m/Y') }}</small>
                                             @else
                                                 <span class="badge badge-success">Válida</span>
-                                                <br><small>{{ $asset->warranty_expires->format('d/m/Y') }}</small>
+                                                <br><small>{{ $asset->warranty_end->format('d/m/Y') }}</small>
                                             @endif
                                         @else
                                             <span class="text-muted">N/A</span>


### PR DESCRIPTION
## Summary
- align controllers and views with `warranty_end` column

## Testing
- `php -l sistema-chamados/app/Http/Controllers/AssetController.php`
- `php -l sistema-chamados/app/Http/Controllers/ReportController.php`
- `php -l sistema-chamados/resources/views/assets/create.blade.php`
- `php -l sistema-chamados/resources/views/assets/edit.blade.php`
- `php -l sistema-chamados/resources/views/assets/show.blade.php`
- `php -l sistema-chamados/resources/views/dashboard.blade.php`
- `php -l sistema-chamados/resources/views/dashboard_new.blade.php`
- `php -l sistema-chamados/resources/views/reports/assets.blade.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886df1999d88329aa0ea76d37c2a0a9